### PR TITLE
More meaningful error when stdin step is incorrect

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "CLI",
     "Regression tests"
   ],
-  "version": "0.3.0",
+  "version": "0.4.0",
   "author": {
     "name": "Olivier Huin",
     "url": "https://github.com/olih"

--- a/pest-spec/simple.pest.yaml
+++ b/pest-spec/simple.pest.yaml
@@ -44,17 +44,6 @@ cases:
           step: 0
         expect:
           snapshot: license.txt
-  unknown-step:
-    title: Use quote as part of the command
-    steps:
-      - title: Read license file
-        run: cat CODE_OF_CONDUCT.md
-      - title: Check wrong step
-        run: cat
-        stdin:
-          step: 1
-        expect:
-          snapshot: no-step.txt
   todo:
     title: Todo use case
     todo: Description of future implementation

--- a/pest-spec/simple.pest.yaml
+++ b/pest-spec/simple.pest.yaml
@@ -44,6 +44,17 @@ cases:
           step: 0
         expect:
           snapshot: license.txt
+  unknown-step:
+    title: Use quote as part of the command
+    steps:
+      - title: Read license file
+        run: cat CODE_OF_CONDUCT.md
+      - title: Check wrong step
+        run: cat
+        stdin:
+          step: 1
+        expect:
+          snapshot: no-step.txt
   todo:
     title: Todo use case
     todo: Description of future implementation

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -14,6 +14,7 @@ type ExecuteCommandLineFailure = {
   category: ExecuteCommandLineFailedCategory;
   run: string;
   response: ShellResponse;
+  message?: string;
 };
 
 type ExecuteCommandLineSuccess = {
@@ -57,8 +58,20 @@ export const executeStep = async (
 ): Promise<ExecuteCommandLineResult> => {
   const { run, stdin } = step;
 
-  const maybeStdin =
-    stdin === undefined ? {} : { input: getInputFromStdin(ctx, stdin) };
+  let maybeStdin = {};
+  if (stdin !== undefined) {
+    const stdinInputResult = getInputFromStdin(ctx, stdin);
+    if (stdinInputResult.status === 'success') {
+      maybeStdin = { input: stdinInputResult.value };
+    } else {
+      return fail({
+        category: 'failed',
+        run,
+        response: { exitCode: 100 },
+        message: stdinInputResult.error.message,
+      });
+    }
+  }
 
   const {
     stdout,

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -67,7 +67,7 @@ export const executeStep = async (
       return fail({
         category: 'failed',
         run,
-        response: { exitCode: 100 },
+        response: { exitCode: 6637 },
         message: stdinInputResult.error.message,
       });
     }

--- a/src/matching-step.ts
+++ b/src/matching-step.ts
@@ -1,5 +1,6 @@
 import { Context, ShellResponse } from './context.js';
 import { ExitCodeModel, ExpectModel, StdinModel } from './pest-model.js';
+import { Result, succeed, fail } from './railway.js';
 
 export const matchExitCode = (
   actual: number,
@@ -14,28 +15,34 @@ export const matchExitCode = (
       return actual >= 1;
   }
 };
+
+type InputStdinResult = Result<string, { message: string }>;
 export const getInputFromStdin = (
   ctx: Context,
   stdin: StdinModel
-): string | undefined => {
+): InputStdinResult => {
   const { receiving, step } = stdin;
   if (step >= ctx.steps.length) {
-    return undefined;
+    return fail({
+      message: `At this stage we have run only ${ctx.steps.length} step(s) but trying to read step at index ${step}`,
+    });
   }
   const stepValue = ctx.steps[step];
   if (stepValue === undefined) {
-    return undefined;
+    return fail({ message: `Step ${step} has no defined output` });
   }
   if (!matchExitCode(stepValue.exitCode, stdin.exitCode)) {
-    return undefined;
+    return fail({
+      message: `Was expecting ${stdin.exitCode} but go ${stepValue.exitCode}`,
+    });
   }
   switch (receiving) {
     case 'stdout':
-      return stepValue.stdout;
+      return succeed(stepValue.stdout || '');
     case 'stderr':
-      return stepValue.stderr;
+      return succeed(stepValue.stderr || '');
     case 'stdout + stderr':
-      return stepValue.stdouterr;
+      return succeed(stepValue.stdouterr || '');
   }
 };
 

--- a/src/matching-step.ts
+++ b/src/matching-step.ts
@@ -24,16 +24,16 @@ export const getInputFromStdin = (
   const { receiving, step } = stdin;
   if (step >= ctx.steps.length) {
     return fail({
-      message: `At this stage we have run only ${ctx.steps.length} step(s) but trying to read step at index ${step}`,
+      message: `At this stage we have run only ${ctx.steps.length} step(s) but trying to read step at index ${step} (832276)`,
     });
   }
   const stepValue = ctx.steps[step];
   if (stepValue === undefined) {
-    return fail({ message: `Step ${step} has no defined output` });
+    return fail({ message: `Step ${step} has no defined output  (411665)`});
   }
   if (!matchExitCode(stepValue.exitCode, stdin.exitCode)) {
     return fail({
-      message: `Was expecting ${stdin.exitCode} but go ${stepValue.exitCode}`,
+      message: `Was expecting ${stdin.exitCode} but go ${stepValue.exitCode} (822595)`,
     });
   }
   switch (receiving) {

--- a/src/run-regression-suite.ts
+++ b/src/run-regression-suite.ts
@@ -164,14 +164,19 @@ const executeStepAndSnaphot = async (params: {
       return succeed('Successful');
     } else {
       const { message, actual, expected } = snapshotResponse.error;
-      const stdouterr = stepResult.error.response.stdouterr;
+      const stepCommandMessage =
+        stepResult.error.message === undefined
+          ? stepResult.error.response.stdouterr
+          : stepResult.error.message;
       reportCaseStep(opts.reportTracker, {
         ...reportingCaseDefault,
         duration,
         err: {
           code: 'ERR_ASSERTION',
           message:
-            stdouterr === undefined ? message : `${message}\n${stdouterr}`,
+            stepCommandMessage === undefined
+              ? message
+              : `${message}\n${stepCommandMessage}`,
           actual,
           expected,
           operator: 'strictEqual',
@@ -188,6 +193,7 @@ const runUseCase = async (params: {
   useCase: UseCaseModel;
 }) => {
   const { opts, ctx, useCase } = params;
+  ctx.steps.length = 0;
   reportStartSuite(
     `${opts.pestModel.title} - ${useCase.name}`,
     opts.runOpts.specFile

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const version = '0.3.0';
+export const version = '0.4.0';


### PR DESCRIPTION
# Summary of the change 

- better message when using wrong step in stdin
- Remove step that would always fail
- Adds id to error message

Fixes: # (issue)

## Code check

- [ ] `yarn ready` does not show any concerning issues
- [ ] the project can be built
- [ ] the documentation has been updated
- [ ] the version has been updated in `package.json`

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Motivation and context

- [ ] improve user experience
- [ ] improve consistency
- [ ] improve security
- [ ] improve documentation
- [ ] reduce risk for unfamiliar tasks
- [ ] automate repetitive tasks

## How Has This Been Tested

- [ ] Unit tests
- [ ] Manual tests
